### PR TITLE
feature : 일정 생성 API

### DIFF
--- a/src/main/java/com/example/spartaschedulemanagement/api/ScheduleController.java
+++ b/src/main/java/com/example/spartaschedulemanagement/api/ScheduleController.java
@@ -1,0 +1,26 @@
+package com.example.spartaschedulemanagement.api;
+
+import com.example.spartaschedulemanagement.dto.CreateScheduleRequest;
+import com.example.spartaschedulemanagement.dto.ScheduleResponse;
+import com.example.spartaschedulemanagement.service.ScheduleService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/v1/schedules")
+public class ScheduleController {
+
+    private final ScheduleService scheduleService;
+
+    @PostMapping
+    public ResponseEntity<?> createSchedule(@RequestBody CreateScheduleRequest request) {
+        ScheduleResponse scheduleResponse = scheduleService.createSchedule(request);
+        return new ResponseEntity<>(scheduleResponse, HttpStatus.CREATED);
+    }
+}

--- a/src/main/java/com/example/spartaschedulemanagement/config/JpaAuditingConfig.java
+++ b/src/main/java/com/example/spartaschedulemanagement/config/JpaAuditingConfig.java
@@ -1,0 +1,9 @@
+package com.example.spartaschedulemanagement.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+
+@Configuration
+@EnableJpaAuditing
+public class JpaAuditingConfig {
+}

--- a/src/main/java/com/example/spartaschedulemanagement/dto/CreateScheduleRequest.java
+++ b/src/main/java/com/example/spartaschedulemanagement/dto/CreateScheduleRequest.java
@@ -1,0 +1,19 @@
+package com.example.spartaschedulemanagement.dto;
+
+import com.example.spartaschedulemanagement.entity.Schedule;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class CreateScheduleRequest {
+
+    private final String title;
+    private final String contents;
+    private final String writer;
+    private final String password;
+
+    public Schedule toEntity() {
+        return Schedule.create(title, contents, writer, password);
+    }
+}

--- a/src/main/java/com/example/spartaschedulemanagement/dto/ScheduleResponse.java
+++ b/src/main/java/com/example/spartaschedulemanagement/dto/ScheduleResponse.java
@@ -1,0 +1,19 @@
+package com.example.spartaschedulemanagement.dto;
+
+import com.example.spartaschedulemanagement.entity.Schedule;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class ScheduleResponse {
+
+    private final Long id;
+    private final String title;
+    private final String contents;
+    private final String writer;
+
+    public static ScheduleResponse of(Schedule schedule) {
+        return new ScheduleResponse(schedule.getId(), schedule.getTitle(), schedule.getContents(), schedule.getWriter());
+    }
+}

--- a/src/main/java/com/example/spartaschedulemanagement/entity/BaseEntity.java
+++ b/src/main/java/com/example/spartaschedulemanagement/entity/BaseEntity.java
@@ -1,0 +1,24 @@
+package com.example.spartaschedulemanagement.entity;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+@Getter
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+public abstract class BaseEntity {
+
+    @CreatedDate
+    @Column(updatable = false)
+//    @Temporal(TemporalType.TIMESTAMP)
+    private LocalDateTime createdAt;
+
+    @LastModifiedDate
+//    @Temporal(TemporalType.TIMESTAMP)
+    private LocalDateTime modifiedAt;
+}

--- a/src/main/java/com/example/spartaschedulemanagement/entity/Schedule.java
+++ b/src/main/java/com/example/spartaschedulemanagement/entity/Schedule.java
@@ -1,0 +1,45 @@
+package com.example.spartaschedulemanagement.entity;
+
+import jakarta.persistence.*;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor
+public class Schedule extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private String title;
+
+    @Column(nullable = false)
+    private String contents;
+
+    @Column(nullable = false)
+    private String writer;
+
+    @Column(nullable = false)
+    private String password;
+
+    @Builder
+    private Schedule(String title, String contents, String writer, String password) {
+        this.title = title;
+        this.contents = contents;
+        this.writer = writer;
+        this.password = password;
+    }
+
+    public static Schedule create(String title, String contents, String writer, String password) {
+        return Schedule.builder()
+                .title(title)
+                .contents(contents)
+                .writer(writer)
+                .password(password)
+                .build();
+    }
+}

--- a/src/main/java/com/example/spartaschedulemanagement/repository/ScheduleRepository.java
+++ b/src/main/java/com/example/spartaschedulemanagement/repository/ScheduleRepository.java
@@ -1,0 +1,7 @@
+package com.example.spartaschedulemanagement.repository;
+
+import com.example.spartaschedulemanagement.entity.Schedule;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ScheduleRepository extends JpaRepository<Schedule, Long> {
+}

--- a/src/main/java/com/example/spartaschedulemanagement/service/ScheduleService.java
+++ b/src/main/java/com/example/spartaschedulemanagement/service/ScheduleService.java
@@ -1,0 +1,22 @@
+package com.example.spartaschedulemanagement.service;
+
+import com.example.spartaschedulemanagement.dto.CreateScheduleRequest;
+import com.example.spartaschedulemanagement.dto.ScheduleResponse;
+import com.example.spartaschedulemanagement.entity.Schedule;
+import com.example.spartaschedulemanagement.repository.ScheduleRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class ScheduleService {
+
+    private final ScheduleRepository scheduleRepository;
+
+    @Transactional
+    public ScheduleResponse createSchedule(final CreateScheduleRequest request) {
+        final Schedule schedule = scheduleRepository.save(request.toEntity());
+        return ScheduleResponse.of(schedule);
+    }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,1 +1,0 @@
-spring.application.name=sparta-schedule-management

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,0 +1,15 @@
+spring:
+  application:
+    name: sparta-schedule-management
+  datasource:
+    url: jdbc:mysql://localhost:3306/sparta_schedule
+    username: root
+    password: won9975744
+    driver-class-name: com.mysql.cj.jdbc.Driver
+  jpa:
+    hibernate:
+      ddl-auto: create-drop
+    properties:
+      hibernate:
+        show_sql: true
+        format_sql: true


### PR DESCRIPTION
### Lv 1. 일정 생성

- [x]  **일정 생성(일정 작성하기)**
    - [x]  일정 생성 시, 포함되어야할 데이터
        - [x]  `일정 제목`, `일정 내용`, `작성자명`, `비밀번호`, `작성/수정일`을 저장
        - [x]  `작성/수정일`은 날짜와 시간을 모두 포함한 형태
    - [x]  각 일정의 고유 식별자(ID)를 자동으로 생성하여 관리
    - [x]  최초 생성 시, `수정일`은 `작성일`과 동일
    - [x]  `작성일`, `수정일` 필드는 `JPA Auditing`을 활용하여 적용합니다.
    - [x]  API 응답에 `비밀번호`는 제외해야 합니다.



