### PR TITLE
feature : 일정 조회 API

### DIFF
--- a/src/main/java/com/example/spartaschedulemanagement/api/ScheduleController.java
+++ b/src/main/java/com/example/spartaschedulemanagement/api/ScheduleController.java
@@ -6,10 +6,9 @@ import com.example.spartaschedulemanagement.service.ScheduleService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 @RestController
 @RequiredArgsConstructor
@@ -19,8 +18,14 @@ public class ScheduleController {
     private final ScheduleService scheduleService;
 
     @PostMapping
-    public ResponseEntity<?> createSchedule(@RequestBody CreateScheduleRequest request) {
+    public ResponseEntity<ScheduleResponse> createSchedule(@RequestBody CreateScheduleRequest request) {
         ScheduleResponse scheduleResponse = scheduleService.createSchedule(request);
         return new ResponseEntity<>(scheduleResponse, HttpStatus.CREATED);
+    }
+
+    @GetMapping
+    public ResponseEntity<List<ScheduleResponse>> getAllSchedule(@RequestParam(required = false) String writer) {
+        List<ScheduleResponse> scheduleResponses = scheduleService.getAllSchedule(writer);
+        return new ResponseEntity<>(scheduleResponses, HttpStatus.OK);
     }
 }

--- a/src/main/java/com/example/spartaschedulemanagement/api/ScheduleController.java
+++ b/src/main/java/com/example/spartaschedulemanagement/api/ScheduleController.java
@@ -2,6 +2,7 @@ package com.example.spartaschedulemanagement.api;
 
 import com.example.spartaschedulemanagement.dto.CreateScheduleRequest;
 import com.example.spartaschedulemanagement.dto.ScheduleResponse;
+import com.example.spartaschedulemanagement.exception.ScheduleNotFoundException;
 import com.example.spartaschedulemanagement.service.ScheduleService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -27,5 +28,16 @@ public class ScheduleController {
     public ResponseEntity<List<ScheduleResponse>> getAllSchedule(@RequestParam(required = false) String writer) {
         List<ScheduleResponse> scheduleResponses = scheduleService.getAllSchedule(writer);
         return new ResponseEntity<>(scheduleResponses, HttpStatus.OK);
+    }
+
+    @GetMapping("/{scheduleId}")
+    private ResponseEntity<ScheduleResponse> getSchedule(@PathVariable Long scheduleId) {
+        ScheduleResponse scheduleResponse;
+        try {
+            scheduleResponse = scheduleService.getScheduleById(scheduleId);
+        } catch (ScheduleNotFoundException e) {
+            return new ResponseEntity<>(HttpStatus.NOT_FOUND);
+        }
+        return new ResponseEntity<>(scheduleResponse, HttpStatus.OK);
     }
 }

--- a/src/main/java/com/example/spartaschedulemanagement/dto/ScheduleResponse.java
+++ b/src/main/java/com/example/spartaschedulemanagement/dto/ScheduleResponse.java
@@ -1,19 +1,39 @@
 package com.example.spartaschedulemanagement.dto;
 
 import com.example.spartaschedulemanagement.entity.Schedule;
-import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 
+import java.time.LocalDateTime;
+
 @Getter
-@AllArgsConstructor
 public class ScheduleResponse {
 
     private final Long id;
     private final String title;
     private final String contents;
     private final String writer;
+    private final LocalDateTime createdAt;
+    private final LocalDateTime modifiedAt;
+
+    @Builder
+    private ScheduleResponse(Long id, String title, String contents, String writer, LocalDateTime createdAt, LocalDateTime modifiedAt) {
+        this.id = id;
+        this.title = title;
+        this.contents = contents;
+        this.writer = writer;
+        this.createdAt = createdAt;
+        this.modifiedAt = modifiedAt;
+    }
 
     public static ScheduleResponse of(Schedule schedule) {
-        return new ScheduleResponse(schedule.getId(), schedule.getTitle(), schedule.getContents(), schedule.getWriter());
+        return ScheduleResponse.builder()
+                .id(schedule.getId())
+                .title(schedule.getTitle())
+                .contents(schedule.getContents())
+                .writer(schedule.getWriter())
+                .createdAt(schedule.getCreatedAt())
+                .modifiedAt(schedule.getModifiedAt())
+                .build();
     }
 }

--- a/src/main/java/com/example/spartaschedulemanagement/exception/ScheduleNotFoundException.java
+++ b/src/main/java/com/example/spartaschedulemanagement/exception/ScheduleNotFoundException.java
@@ -1,0 +1,8 @@
+package com.example.spartaschedulemanagement.exception;
+
+public class ScheduleNotFoundException extends RuntimeException {
+
+    public ScheduleNotFoundException(Long id) {
+        super(id + "는 존재하지 않은 일정입니다.");
+    }
+}

--- a/src/main/java/com/example/spartaschedulemanagement/repository/ScheduleRepository.java
+++ b/src/main/java/com/example/spartaschedulemanagement/repository/ScheduleRepository.java
@@ -2,6 +2,14 @@ package com.example.spartaschedulemanagement.repository;
 
 import com.example.spartaschedulemanagement.entity.Schedule;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+
+import java.util.List;
 
 public interface ScheduleRepository extends JpaRepository<Schedule, Long> {
+
+    List<Schedule> findAllByWriterOrderByModifiedAtDesc(String writer);
+
+    @Query("select s from Schedule s order by s.modifiedAt DESC")
+    List<Schedule> findAllOrderByModifiedAtDesc();
 }

--- a/src/main/java/com/example/spartaschedulemanagement/service/ScheduleService.java
+++ b/src/main/java/com/example/spartaschedulemanagement/service/ScheduleService.java
@@ -7,6 +7,9 @@ import com.example.spartaschedulemanagement.repository.ScheduleRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.StringUtils;
+
+import java.util.List;
 
 @Service
 @RequiredArgsConstructor
@@ -18,5 +21,21 @@ public class ScheduleService {
     public ScheduleResponse createSchedule(final CreateScheduleRequest request) {
         final Schedule schedule = scheduleRepository.save(request.toEntity());
         return ScheduleResponse.of(schedule);
+    }
+
+    @Transactional(readOnly = true)
+    public List<ScheduleResponse> getAllSchedule(String writer) {
+        List<Schedule> schedules = getAllScheduleByWriter(writer);
+        return schedules.stream()
+                .map(ScheduleResponse::of)
+                .toList();
+    }
+
+    private List<Schedule> getAllScheduleByWriter(String writer) {
+        if (false == StringUtils.hasText(writer)) {
+            return scheduleRepository.findAllOrderByModifiedAtDesc();
+        }
+
+        return scheduleRepository.findAllByWriterOrderByModifiedAtDesc(writer);
     }
 }

--- a/src/main/java/com/example/spartaschedulemanagement/service/ScheduleService.java
+++ b/src/main/java/com/example/spartaschedulemanagement/service/ScheduleService.java
@@ -3,6 +3,7 @@ package com.example.spartaschedulemanagement.service;
 import com.example.spartaschedulemanagement.dto.CreateScheduleRequest;
 import com.example.spartaschedulemanagement.dto.ScheduleResponse;
 import com.example.spartaschedulemanagement.entity.Schedule;
+import com.example.spartaschedulemanagement.exception.ScheduleNotFoundException;
 import com.example.spartaschedulemanagement.repository.ScheduleRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -29,6 +30,12 @@ public class ScheduleService {
         return schedules.stream()
                 .map(ScheduleResponse::of)
                 .toList();
+    }
+
+    public ScheduleResponse getScheduleById(Long id) {
+        Schedule schedule = scheduleRepository.findById(id)
+                .orElseThrow(() -> new ScheduleNotFoundException(id));
+        return ScheduleResponse.of(schedule);
     }
 
     private List<Schedule> getAllScheduleByWriter(String writer) {


### PR DESCRIPTION
### Lv 2. 일정 조회

- **전체 일정 조회**
    - [x]  `작성자명`을 기준으로 등록된 일정 목록을 전부 조회
        - [x]  `작성자명`은 조회 조건으로 포함될 수도 있고, 포함되지 않을 수도 있습니다.
        - [x]  하나의 API로 작성해야 합니다.
    - [x]  `수정일` 기준 내림차순으로 정렬
   
-  **선택 일정 조회**
    - [x]  선택한 일정 단건의 정보를 조회할 수 있습니다.
        - [x]  일정의 고유 식별자(ID)를 사용하여 조회합니다.

- **공통 요구사항**
    - [x]  API 응답에 `비밀번호`는 제외해야 합니다.
