### PR TITLE
feature : 일정 수정 API

### DIFF
--- a/src/main/java/com/example/spartaschedulemanagement/api/ScheduleController.java
+++ b/src/main/java/com/example/spartaschedulemanagement/api/ScheduleController.java
@@ -1,6 +1,7 @@
 package com.example.spartaschedulemanagement.api;
 
 import com.example.spartaschedulemanagement.dto.CreateScheduleRequest;
+import com.example.spartaschedulemanagement.dto.EditScheduleTitleAndWriterRequest;
 import com.example.spartaschedulemanagement.dto.ScheduleResponse;
 import com.example.spartaschedulemanagement.exception.ScheduleNotFoundException;
 import com.example.spartaschedulemanagement.service.ScheduleService;
@@ -37,6 +38,17 @@ public class ScheduleController {
             scheduleResponse = scheduleService.getScheduleById(scheduleId);
         } catch (ScheduleNotFoundException e) {
             return new ResponseEntity<>(HttpStatus.NOT_FOUND);
+        }
+        return new ResponseEntity<>(scheduleResponse, HttpStatus.OK);
+    }
+
+    @PatchMapping("/{scheduleId}")
+    public ResponseEntity<ScheduleResponse> editScheduleTitleAndWriter(@PathVariable Long scheduleId, @RequestBody EditScheduleTitleAndWriterRequest request) {
+        ScheduleResponse scheduleResponse;
+        try {
+            scheduleResponse = scheduleService.editScheduleTitleAndWriter(scheduleId, request);
+        } catch (RuntimeException e) {
+            return new ResponseEntity<>(HttpStatus.BAD_REQUEST);
         }
         return new ResponseEntity<>(scheduleResponse, HttpStatus.OK);
     }

--- a/src/main/java/com/example/spartaschedulemanagement/dto/EditScheduleTitleAndWriterRequest.java
+++ b/src/main/java/com/example/spartaschedulemanagement/dto/EditScheduleTitleAndWriterRequest.java
@@ -1,0 +1,11 @@
+package com.example.spartaschedulemanagement.dto;
+
+import lombok.Getter;
+
+@Getter
+public class EditScheduleTitleAndWriterRequest {
+
+    private String title;
+    private String writer;
+    private String password;
+}

--- a/src/main/java/com/example/spartaschedulemanagement/entity/Schedule.java
+++ b/src/main/java/com/example/spartaschedulemanagement/entity/Schedule.java
@@ -42,4 +42,9 @@ public class Schedule extends BaseEntity {
                 .password(password)
                 .build();
     }
+
+    public void updateTitleAndWriter(String title, String writer) {
+        this.title = title;
+        this.writer = writer;
+    }
 }

--- a/src/main/java/com/example/spartaschedulemanagement/exception/InvalidPasswordException.java
+++ b/src/main/java/com/example/spartaschedulemanagement/exception/InvalidPasswordException.java
@@ -1,0 +1,8 @@
+package com.example.spartaschedulemanagement.exception;
+
+public class InvalidPasswordException extends RuntimeException {
+
+    public InvalidPasswordException() {
+        super("비밀번호가 일치하지 않습니다.");
+    }
+}


### PR DESCRIPTION
### Lv 3. 일정 수정 

- [x]  **선택한 일정 수정**
    - [x]  선택한 일정 내용 중 `일정 제목`, `작성자명` 만 수정 가능
        - [x]  서버에 일정 수정을 요청할 때 `비밀번호`를 함께 전달합니다.
        -[ x]  `작성일` 은 변경할 수 없으며, `수정일` 은 수정 완료 시, 수정한 시점으로 변경되어야 합니다.
    - [x]  API 응답에 `비밀번호`는 제외해야 합니다.