### PR TITLE
feature : 댓글 생성 API

### DIFF
--- a/src/main/java/com/example/spartaschedulemanagement/api/ScheduleController.java
+++ b/src/main/java/com/example/spartaschedulemanagement/api/ScheduleController.java
@@ -1,9 +1,8 @@
 package com.example.spartaschedulemanagement.api;
 
-import com.example.spartaschedulemanagement.dto.CreateScheduleRequest;
-import com.example.spartaschedulemanagement.dto.EditScheduleTitleAndWriterRequest;
-import com.example.spartaschedulemanagement.dto.ScheduleResponse;
+import com.example.spartaschedulemanagement.dto.*;
 import com.example.spartaschedulemanagement.exception.ScheduleNotFoundException;
+import com.example.spartaschedulemanagement.service.CommentService;
 import com.example.spartaschedulemanagement.service.ScheduleService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -18,6 +17,7 @@ import java.util.List;
 public class ScheduleController {
 
     private final ScheduleService scheduleService;
+    private final CommentService commentService;
 
     @PostMapping
     public ResponseEntity<ScheduleResponse> createSchedule(@RequestBody CreateScheduleRequest request) {
@@ -59,4 +59,9 @@ public class ScheduleController {
         return new ResponseEntity<>(HttpStatus.OK);
     }
 
+    @PostMapping("/{scheduleId}/comments")
+    public ResponseEntity<CommentResponse> addComment(@PathVariable Long scheduleId, @RequestBody CreateCommentRequest request) {
+        CommentResponse commentResponse = commentService.addComment(scheduleId, request);
+        return new ResponseEntity<>(commentResponse, HttpStatus.OK);
+    }
 }

--- a/src/main/java/com/example/spartaschedulemanagement/dto/CommentResponse.java
+++ b/src/main/java/com/example/spartaschedulemanagement/dto/CommentResponse.java
@@ -1,0 +1,28 @@
+package com.example.spartaschedulemanagement.dto;
+
+import com.example.spartaschedulemanagement.entity.Comment;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+public class CommentResponse {
+
+    private final Long id;
+    private final String contents;
+    private final String writer;
+
+    @Builder
+    private CommentResponse(Long id, String contents, String writer) {
+        this.id = id;
+        this.contents = contents;
+        this.writer = writer;
+    }
+
+    public static CommentResponse of(Comment comment) {
+        return CommentResponse.builder()
+                .id(comment.getId())
+                .contents(comment.getContents())
+                .writer(comment.getWriter())
+                .build();
+    }
+}

--- a/src/main/java/com/example/spartaschedulemanagement/dto/CreateCommentRequest.java
+++ b/src/main/java/com/example/spartaschedulemanagement/dto/CreateCommentRequest.java
@@ -1,0 +1,19 @@
+package com.example.spartaschedulemanagement.dto;
+
+import com.example.spartaschedulemanagement.entity.Comment;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class CreateCommentRequest {
+
+    private final String contents;
+    private final String writer;
+    private final String password;
+
+    public Comment toEntity(Long scheduleId) {
+        return Comment.create(scheduleId, contents, writer, password);
+    }
+
+}

--- a/src/main/java/com/example/spartaschedulemanagement/entity/Comment.java
+++ b/src/main/java/com/example/spartaschedulemanagement/entity/Comment.java
@@ -1,0 +1,43 @@
+package com.example.spartaschedulemanagement.entity;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor
+public class Comment extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private Long scheduleId;
+
+    private String contents;
+    private String writer;
+    private String password;
+
+    @Builder
+    private Comment(Long scheduleId, String contents, String writer, String password) {
+        this.scheduleId = scheduleId;
+        this.contents = contents;
+        this.writer = writer;
+        this.password = password;
+    }
+
+    public static Comment create(Long scheduleId, String contents, String writer, String password) {
+        return Comment.builder()
+                .scheduleId(scheduleId)
+                .contents(contents)
+                .writer(writer)
+                .password(password)
+                .build();
+    }
+
+}

--- a/src/main/java/com/example/spartaschedulemanagement/entity/Schedule.java
+++ b/src/main/java/com/example/spartaschedulemanagement/entity/Schedule.java
@@ -28,6 +28,9 @@ public class Schedule extends BaseEntity {
     @Column(nullable = false)
     private String password;
 
+    @Column(nullable = false)
+    private int commentCount;
+
     @Builder
     private Schedule(String title, String contents, String writer, String password) {
         this.title = title;
@@ -48,5 +51,14 @@ public class Schedule extends BaseEntity {
     public void updateTitleAndWriter(String title, String writer) {
         this.title = title;
         this.writer = writer;
+    }
+
+    public boolean hasMaxCommentCount() {
+        final int maxCommentCount = 10;
+        return commentCount >= maxCommentCount;
+    }
+
+    public void increaseCommentCount() {
+        commentCount += 1;
     }
 }

--- a/src/main/java/com/example/spartaschedulemanagement/exception/CommentLimitExceededException.java
+++ b/src/main/java/com/example/spartaschedulemanagement/exception/CommentLimitExceededException.java
@@ -1,0 +1,8 @@
+package com.example.spartaschedulemanagement.exception;
+
+public class CommentLimitExceededException extends RuntimeException {
+
+    public CommentLimitExceededException() {
+        super("댓글은 10개 이하까지만 작성 가능합니다.");
+    }
+}

--- a/src/main/java/com/example/spartaschedulemanagement/repository/CommentRepository.java
+++ b/src/main/java/com/example/spartaschedulemanagement/repository/CommentRepository.java
@@ -1,0 +1,7 @@
+package com.example.spartaschedulemanagement.repository;
+
+import com.example.spartaschedulemanagement.entity.Comment;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface CommentRepository extends JpaRepository<Comment, Long> {
+}

--- a/src/main/java/com/example/spartaschedulemanagement/service/CommentService.java
+++ b/src/main/java/com/example/spartaschedulemanagement/service/CommentService.java
@@ -1,0 +1,38 @@
+package com.example.spartaschedulemanagement.service;
+
+import com.example.spartaschedulemanagement.dto.CommentResponse;
+import com.example.spartaschedulemanagement.dto.CreateCommentRequest;
+import com.example.spartaschedulemanagement.entity.Comment;
+import com.example.spartaschedulemanagement.entity.Schedule;
+import com.example.spartaschedulemanagement.exception.CommentLimitExceededException;
+import com.example.spartaschedulemanagement.exception.ScheduleNotFoundException;
+import com.example.spartaschedulemanagement.repository.CommentRepository;
+import com.example.spartaschedulemanagement.repository.ScheduleRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class CommentService {
+
+    private final CommentRepository commentRepository;
+    private final ScheduleRepository scheduleRepository;
+
+    @Transactional
+    public CommentResponse addComment(final Long scheduleId, final CreateCommentRequest request) {
+
+        Schedule schedule = scheduleRepository.findById(scheduleId)
+                .orElseThrow(() -> new ScheduleNotFoundException(scheduleId));
+
+        if (schedule.hasMaxCommentCount()) {
+            throw new CommentLimitExceededException();
+        }
+
+        schedule.increaseCommentCount();
+        Comment comment = commentRepository.save(request.toEntity(scheduleId));
+
+        return CommentResponse.of(comment);
+    }
+
+}


### PR DESCRIPTION
### Lv 5. 댓글 생성

- [x]  **댓글 생성(댓글 작성하기)**
    - [x]  일정에 댓글을 작성할 수 있습니다.
    - [x]  댓글 생성 시, 포함되어야할 데이터
        - [x]  `댓글 내용`, `작성자명`, `비밀번호`, `작성/수정일`, `일정 고유식별자(ID)`를 저장
        - [x]  `작성/수정일`은 날짜와 시간을 모두 포함한 형태
    - [x]  각 일정의 고유 식별자(ID)를 자동으로 생성하여 관리
    - [x]  최초 생성 시, `수정일`은 `작성일`과 동일
    - [x]  `작성일`, `수정일` 필드는 `JPA Auditing`을 활용하여 적용합니다.
    - [x]  하나의 일정에는 댓글을 10개까지만 작성할 수 있습니다.
    - [x]  API 응답에 `비밀번호`는 제외해야 합니다.


