### PR TITLE
feature : 일정 단건 조회 시 댓글 리스트 추가

### DIFF
--- a/src/main/java/com/example/spartaschedulemanagement/api/ScheduleController.java
+++ b/src/main/java/com/example/spartaschedulemanagement/api/ScheduleController.java
@@ -32,14 +32,14 @@ public class ScheduleController {
     }
 
     @GetMapping("/{scheduleId}")
-    private ResponseEntity<ScheduleResponse> getSchedule(@PathVariable Long scheduleId) {
-        ScheduleResponse scheduleResponse;
+    private ResponseEntity<ScheduleWithCommentsResponse> getSchedule(@PathVariable Long scheduleId) {
+        ScheduleWithCommentsResponse scheduleWithCommentsResponse;
         try {
-            scheduleResponse = scheduleService.getScheduleById(scheduleId);
+            scheduleWithCommentsResponse = scheduleService.getScheduleById(scheduleId);
         } catch (ScheduleNotFoundException e) {
             return new ResponseEntity<>(HttpStatus.NOT_FOUND);
         }
-        return new ResponseEntity<>(scheduleResponse, HttpStatus.OK);
+        return new ResponseEntity<>(scheduleWithCommentsResponse, HttpStatus.OK);
     }
 
     @PatchMapping("/{scheduleId}")
@@ -64,4 +64,5 @@ public class ScheduleController {
         CommentResponse commentResponse = commentService.addComment(scheduleId, request);
         return new ResponseEntity<>(commentResponse, HttpStatus.OK);
     }
+
 }

--- a/src/main/java/com/example/spartaschedulemanagement/dto/CommentResponse.java
+++ b/src/main/java/com/example/spartaschedulemanagement/dto/CommentResponse.java
@@ -4,25 +4,35 @@ import com.example.spartaschedulemanagement.entity.Comment;
 import lombok.Builder;
 import lombok.Getter;
 
+import java.time.LocalDateTime;
+
 @Getter
 public class CommentResponse {
 
     private final Long id;
     private final String contents;
     private final String writer;
+    private final LocalDateTime createdAt;
+    private final LocalDateTime modifiedAt;
+
 
     @Builder
-    private CommentResponse(Long id, String contents, String writer) {
+    private CommentResponse(Long id, String contents, String writer, LocalDateTime createdAt, LocalDateTime modifiedAt) {
         this.id = id;
         this.contents = contents;
         this.writer = writer;
+        this.createdAt = createdAt;
+        this.modifiedAt = modifiedAt;
     }
+
 
     public static CommentResponse of(Comment comment) {
         return CommentResponse.builder()
                 .id(comment.getId())
                 .contents(comment.getContents())
                 .writer(comment.getWriter())
+                .createdAt(comment.getCreatedAt())
+                .modifiedAt(comment.getModifiedAt())
                 .build();
     }
 }

--- a/src/main/java/com/example/spartaschedulemanagement/dto/ScheduleWithCommentsResponse.java
+++ b/src/main/java/com/example/spartaschedulemanagement/dto/ScheduleWithCommentsResponse.java
@@ -1,0 +1,28 @@
+package com.example.spartaschedulemanagement.dto;
+
+import com.example.spartaschedulemanagement.entity.Comment;
+import com.example.spartaschedulemanagement.entity.Schedule;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+public class ScheduleWithCommentsResponse {
+
+    private final ScheduleResponse schedule;
+    private final List<CommentResponse> comments;
+
+    private ScheduleWithCommentsResponse(ScheduleResponse schedule, List<CommentResponse> comments) {
+        this.schedule = schedule;
+        this.comments = comments;
+    }
+
+    public static ScheduleWithCommentsResponse of(Schedule schedule, List<Comment> comments) {
+        return new ScheduleWithCommentsResponse(
+                ScheduleResponse.of(schedule),
+                comments.stream()
+                        .map(CommentResponse::of)
+                        .toList()
+        );
+    }
+}

--- a/src/main/java/com/example/spartaschedulemanagement/repository/CommentRepository.java
+++ b/src/main/java/com/example/spartaschedulemanagement/repository/CommentRepository.java
@@ -3,5 +3,9 @@ package com.example.spartaschedulemanagement.repository;
 import com.example.spartaschedulemanagement.entity.Comment;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface CommentRepository extends JpaRepository<Comment, Long> {
+
+    List<Comment> findAllByScheduleId(Long id);
 }

--- a/src/main/java/com/example/spartaschedulemanagement/service/ScheduleService.java
+++ b/src/main/java/com/example/spartaschedulemanagement/service/ScheduleService.java
@@ -3,9 +3,12 @@ package com.example.spartaschedulemanagement.service;
 import com.example.spartaschedulemanagement.dto.CreateScheduleRequest;
 import com.example.spartaschedulemanagement.dto.EditScheduleTitleAndWriterRequest;
 import com.example.spartaschedulemanagement.dto.ScheduleResponse;
+import com.example.spartaschedulemanagement.dto.ScheduleWithCommentsResponse;
+import com.example.spartaschedulemanagement.entity.Comment;
 import com.example.spartaschedulemanagement.entity.Schedule;
 import com.example.spartaschedulemanagement.exception.InvalidPasswordException;
 import com.example.spartaschedulemanagement.exception.ScheduleNotFoundException;
+import com.example.spartaschedulemanagement.repository.CommentRepository;
 import com.example.spartaschedulemanagement.repository.ScheduleRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -19,6 +22,7 @@ import java.util.List;
 public class ScheduleService {
 
     private final ScheduleRepository scheduleRepository;
+    private final CommentRepository commentRepository;
 
     @Transactional
     public ScheduleResponse createSchedule(final CreateScheduleRequest request) {
@@ -35,10 +39,13 @@ public class ScheduleService {
     }
 
     @Transactional(readOnly = true)
-    public ScheduleResponse getScheduleById(Long id) {
+    public ScheduleWithCommentsResponse getScheduleById(Long id) {
         Schedule schedule = scheduleRepository.findById(id)
                 .orElseThrow(() -> new ScheduleNotFoundException(id));
-        return ScheduleResponse.of(schedule);
+
+        List<Comment> comments = commentRepository.findAllByScheduleId(schedule.getId());
+
+        return ScheduleWithCommentsResponse.of(schedule, comments);
     }
 
     @Transactional


### PR DESCRIPTION
### Lv 6. 일정 단건 조회 업그레이드 

- [x]  **일정 단건 조회 업그레이드**
    - [x]  일정 단건 조회 시, 해당 일정에 등록된 댓글들을 포함하여 함께 응답합니다.
    - [x]  API 응답에 `비밀번호`는 제외해야 합니다.